### PR TITLE
Show the "Disabled in edit mode" message using the user's language

### DIFF
--- a/blocks/pure_cookies_notice/view.php
+++ b/blocks/pure_cookies_notice/view.php
@@ -8,11 +8,14 @@
 defined('C5_EXECUTE') or die('Access Denied.');
 $c = Page::getCurrentPage();
 if ($c->isEditMode()) {
+    $localization = Localization::getInstance();
+    $localization->pushActiveContext('ui');
     ?>
     <div class="ccm-edit-mode-disabled-item">
         <?php echo t('Cookies Notice is disabled in edit mode.') ?>
     </div>
     <?php
+    $localization->popActiveContext();
 } elseif (empty($read)) {
     $wrapperClasses = [
         $position,


### PR DESCRIPTION
Currently the `Cookies Notice is disabled in edit mode.` message is shown using the page language.

BTW, since it's a message for the user editing the page, we should use the user's language.