### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "guyasyou/pure_cookies_notice",
+    "description": "Package for CMS concrete5 CMS that allows to notify users of anything, including the use of cookies (The Cookie Law Explained).",
+    "type" : "concrete5-package",
+    "license": "MIT"
+}


### PR DESCRIPTION
What about adding support to install this package via composer?

All you have to do is:
- customize this `composer.json` file by adding any detail you want (author, homepage, keywords, ...) - see https://getcomposer.org/doc/04-schema.md
- submit `https://github.com/guyasyou/Pure-Cookies-Notice` to [Packagist](https://packagist.org/packages/submit)
- enjoy composer!

For instance, it will be possible to do the following:
```bash
# Create a new concrete5 project
composer create-project concrete5/composer your_project_name

# Enter the project directory
cd your_project_name

# Install concrete5
./concrete/bin/concrete5 c5:install -i

# Download the Pure-Cookies-Notice package
composer require guyasyou/pure_cookies_notice

# Install Pure-Cookies-Notice package in concrete5
./concrete/bin/concrete5 c5:package-install pure_cookies_notice
```



