### PR TITLE
Avoid accessing undefined variables

### DIFF
--- a/blocks/pure_cookies_notice/controller.php
+++ b/blocks/pure_cookies_notice/controller.php
@@ -240,7 +240,16 @@ class Controller extends BlockController implements TrackableInterface, FileTrac
 
     public function add()
     {
+        $this->set('title', '');
+        $this->set('agreeText', '');
         $this->set('position', 'bottom');
+        $this->set('textColor', '');
+        $this->set('linkColor', '');
+        $this->set('backgroundColor', '');
+        $this->set('sitewideCookie', false);
+        $this->set('onlyForEU', false);
+        $this->set('interactionImpliesOk', false);
+        $this->set('sitewideCookie', true);
         $this->edit();
     }
 

--- a/blocks/pure_cookies_notice/form.php
+++ b/blocks/pure_cookies_notice/form.php
@@ -12,6 +12,18 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var Concrete\Core\Form\Service\Form $form */
 /* @var Concrete\Core\Block\View\BlockView $this */
 /* @var Concrete\Core\Block\View\BlockView $view */
+
+/* @var string $title */
+/* @var string $agreeText */
+/* @var string $textColor */
+/* @var string $linkColor */
+/* @var string $backgroundColor */
+/* @var array $positions */
+/* @var string $position */
+/* @var bool $geolocationSupported */
+/* @var bool|string $onlyForEU */
+/* @var bool|string $interactionImpliesOk */
+/* @var bool|string $sitewideCookie */
 ?>
 <div class="pure-cookies-notice-edit-container">
     <ul id="pure-cookies-notice-edit-tabs" class="nav nav-tabs" role="tablist">


### PR DESCRIPTION
When adding a new Cookies Notice block, the PHP code uses undefined variables (you can see it by enabling the `Consider warnings as errors` option in the `/dashboard/system/environment/debug` dashboard page.

Let's avoid this. 