### PR TITLE
Improve translation of missing required field messages

### DIFF
--- a/blocks/pure_cookies_notice/controller.php
+++ b/blocks/pure_cookies_notice/controller.php
@@ -271,10 +271,10 @@ class Controller extends BlockController implements TrackableInterface, FileTrac
         $e = $this->app->make('error');
 
         if (empty($data['content'])) {
-            $e->add(t(/*i18n: %s is the name of a field */'Required field: %s', 'Content'));
+            $e->add(t('Field "Content" is required'));
         }
         if (empty($data['position'])) {
-            $e->add(t(/*i18n: %s is the name of a field */'Required field: %s', 'Position'));
+            $e->add(t('Field "Position" is required'));
         }
 
         return $e;

--- a/blocks/pure_cookies_notice/controller.php
+++ b/blocks/pure_cookies_notice/controller.php
@@ -271,10 +271,10 @@ class Controller extends BlockController implements TrackableInterface, FileTrac
         $e = $this->app->make('error');
 
         if (empty($data['content'])) {
-            $e->add(t('%s is required', 'Content'));
+            $e->add(t(/*i18n: %s is the name of a field */'Required field: %s', 'Content'));
         }
         if (empty($data['position'])) {
-            $e->add(t('%s is required', 'Position'));
+            $e->add(t(/*i18n: %s is the name of a field */'Required field: %s', 'Position'));
         }
 
         return $e;


### PR DESCRIPTION
Translating concatenated strings is not translation-friendly.

For instance, I'd translate in Italian:
- "Content is required" as "Il contenuto è richiesto"
- "Position is required" as "La posizione è richiesta"

So, I'm having a hard time translating "%s is required" (it would need to be both "%s è richiesto" and "%s è richiesta").
This change would make translation life easier :wink: