### PR TITLE
Revert "Add alert preview"

### DIFF
--- a/blocks/pure_cookies_notice/controller.php
+++ b/blocks/pure_cookies_notice/controller.php
@@ -17,11 +17,6 @@ use Concrete\Core\Geolocator\GeolocatorService;
 use Exception;
 use Punic\Territory;
 use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
-use Concrete\Core\Http\ResponseFactoryInterface;
-use Concrete\Core\Error\UserMessageException;
-use Doctrine\ORM\EntityManagerInterface;
-use Concrete\Core\Entity\Block\BlockType\BlockType;
-use Concrete\Core\Block\View\BlockView;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
@@ -48,7 +43,6 @@ class Controller extends BlockController implements TrackableInterface, FileTrac
     public $interactionImpliesOk;
     public $sitewideCookie;
     public $onlyForEU;
-    private $previewing = false;
 
     /**
      * @var \Concrete\Core\Statistics\UsageTracker\AggregateTracker
@@ -204,39 +198,34 @@ class Controller extends BlockController implements TrackableInterface, FileTrac
         return $this->shouldShowAgreementResult;
     }
 
-    private static function generateCss(Controller $controller)
+    private function generateStylesheet()
     {
         $lines = ['<style>'];
-        $lines[] = "#pure-cookies-notice-{$controller->bID} {";
-        if (!empty($controller->textColor)) {
-            $lines[] = "\tcolor: {$controller->textColor};";
+        $lines[] = "#pure-cookies-notice-{$this->bID} {";
+        if (!empty($this->textColor)) {
+            $lines[] = "\tcolor: {$this->textColor};";
         }
-        if (!empty($controller->backgroundColor)) {
-            $lines[] = "\tbackground: {$controller->backgroundColor};";
-        }
-        $lines[] = '}';
-        $lines[] = "#pure-cookies-notice-{$controller->bID} a {";
-        if (!empty($controller->linkColor)) {
-            $lines[] = "\tcolor: {$controller->linkColor};";
-        }
-        elseif (!empty($controller->textColor)) {
-            $lines[] = "\tcolor: {$controller->textColor};";
+        if (!empty($this->backgroundColor)) {
+            $lines[] = "\tbackground: {$this->backgroundColor};";
         }
         $lines[] = '}';
-        $lines[] = "#pure-cookies-notice-{$controller->bID} .pure-cookies-notice-close-button {";
-        if (!empty($controller->textColor)) {
-            $lines[] = "\tcolor: {$controller->textColor};";
-            $lines[] = "\tborder-color: {$controller->textColor};";
+        $lines[] = "#pure-cookies-notice-{$this->bID} a {";
+        if (!empty($this->linkColor)) {
+            $lines[] = "\tcolor: {$this->linkColor};";
+        }
+        elseif (!empty($this->textColor)) {
+            $lines[] = "\tcolor: {$this->textColor};";
+        }
+        $lines[] = '}';
+        $lines[] = "#pure-cookies-notice-{$this->bID} .pure-cookies-notice-close-button {";
+        if (!empty($this->textColor)) {
+            $lines[] = "\tcolor: {$this->textColor};";
+            $lines[] = "\tborder-color: {$this->textColor};";
         }
         $lines[] = '}';
         $lines[] = '</style>';
 
         return implode("\n", $lines);
-    }
-
-    private function generateStylesheet()
-    {
-        return self::generateCss($this, $this->bID);
     }
 
     public function on_start()
@@ -267,7 +256,6 @@ class Controller extends BlockController implements TrackableInterface, FileTrac
     public function edit()
     {
         $this->set('ui', $this->app->make('helper/concrete/ui'));
-        $this->set('token', $this->app->make('token'));
         $this->set('geolocationSupported', $this->geolocationSupported());
         $this->set('color', $this->app->make('helper/form/color'));
         $this->requireAsset('css', 'pure_cookies_notice/edit');
@@ -279,14 +267,9 @@ class Controller extends BlockController implements TrackableInterface, FileTrac
 
     public function view()
     {
-        $this->set('previewing', $this->previewing);
-        if ($this->previewing || $this->shouldShowAgreement()) {
+        if ($this->shouldShowAgreement()) {
             $this->set('read', false);
-            $this->set('bID', $this->bID);
-            $this->set('title', $this->title);
             $this->set('content', $this->getContent());
-            $this->set('agreeText', $this->agreeText);
-            $this->set('position', $this->position);
         } else {
             $this->set('read', true);
         }
@@ -330,43 +313,5 @@ class Controller extends BlockController implements TrackableInterface, FileTrac
     {
         parent::delete();
         $this->tracker->forget($this);
-    }
-
-    public function action_generate_preview()
-    {
-        $token = $this->app->make('token');
-        if (!$token->validate('pure-cookie-notice-preview')) {
-            if (class_exists(UserMessageException::class)) {
-                throw new UserMessageException($token->getErrorMessage());
-            }
-            throw new Exception($token->getErrorMessage());
-        }
-        $em = $this->app->make(EntityManagerInterface::class);
-        if (method_exists($this, 'getBlockTypeID')) {
-            $blockType = $em->find(BlockType::class, $this->getBlockTypeID());
-        } else {
-            $blockType = $em->getRepository(BlockType::class)->findOneBy(['btHandle' => $this->btHandle]);
-        }
-        $blockTypeController = $blockType->getController();
-        $post = $this->request->request;
-
-        $blockTypeController->bID = md5(mt_rand() . '@' . microtime(true));
-        $blockTypeController->title = $post->get('title');
-        $blockTypeController->content = LinkAbstractor::translateTo($post->get('content'));
-        $blockTypeController->agreeText = $post->get('agreeText');
-        $blockTypeController->position = $post->get('position');
-        $blockTypeController->textColor = $post->get('textColor');
-        $blockTypeController->linkColor = $post->get('linkColor');
-        $blockTypeController->backgroundColor = $post->get('backgroundColor');
-        $blockTypeController->previewing = true;
-        $blockView = new BlockView($blockType);
-        ob_start();
-        $blockView->render('view');
-        $html = ob_get_contents();
-        ob_end_clean();
-        $html = '<script> $("head").append(' . json_encode(self::generateCss($blockTypeController)) . '); </script>' . $html;
-        $html = $this->generateCss($blockTypeController, $blockTypeController->bID, true). $html;
-
-        return $this->app->make(ResponseFactoryInterface::class)->json(['html' => $html]);
     }
 }

--- a/blocks/pure_cookies_notice/form.php
+++ b/blocks/pure_cookies_notice/form.php
@@ -8,7 +8,6 @@
 defined('C5_EXECUTE') or die('Access Denied.');
 
 /* @var Concrete\Core\Application\Service\UserInterface $ui */
-/* @var Concrete\Core\Validation\CSRF\Token $token */
 /* @var Concrete\Core\Form\Service\Widget\Color $color */
 /* @var Concrete\Package\PureCookiesNotice\Block\PureCookiesNotice\Controller $controller */
 /* @var Concrete\Core\Form\Service\Form $form */
@@ -33,7 +32,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
         ['pure-cookies-notice-edit-basics', t('Basics'), true],
         ['pure-cookies-notice-edit-colors', t('Colors')],
         ['pure-cookies-notice-edit-advanced', t('Advanced')],
-        ['pure-cookies-notice-edit-preview', t('Preview')],
     ]) ?>
 
     <div class="ccm-tab-content" id="ccm-tab-content-pure-cookies-notice-edit-basics">
@@ -135,37 +133,10 @@ defined('C5_EXECUTE') or die('Access Denied.');
         </fieldset>
     </div>
 
-    <div class="ccm-tab-content" id="ccm-tab-content-pure-cookies-notice-edit-preview">
-        <div id="ccm-tab-content-pure-cookies-notice-edit-preview-view"></div>
-    </div>
 </div>
 
 <script>
     $(function() {
         $().pureInputLengthCounter($('.pure-cookies-notice-edit-container input[maxlength]'));
-        $('a[data-tab="pure-cookies-notice-edit-preview"]').on('click', function(e) {
-            e.preventDefault();
-            var $preview = $('#ccm-tab-content-pure-cookies-notice-edit-preview'),
-                $form = $preview.closest('form'),
-                send = {
-                    ccm_token: <?= json_encode($token->generate('pure-cookie-notice-preview')) ?>
-                }
-            $preview.empty();
-            $form.find('input,textarea,select').each(function() {
-                var $field = $(this),
-                    name = $field.attr('name');
-                if (name) {
-                    send[name] = $field.val();
-                }
-            });
-            new ConcreteAjaxRequest({
-                url: <?= json_encode((string) $view->action('generate_preview')) ?>,
-                data: send,
-                dataType: 'json',
-                success: function(data) {
-                    $preview.html(data.html);
-                }
-            });
-        }); 
     });
 </script>

--- a/blocks/pure_cookies_notice/view.css
+++ b/blocks/pure_cookies_notice/view.css
@@ -4,11 +4,9 @@
  * www.pure-web.ru
  * © 2017
  */
- .pure-cookies-notice-wrapper:not(.pure-cookies-notice-wrapper-preview) {
+.pure-cookies-notice-wrapper {
   position: fixed;
   z-index: 1000;
-}
-.pure-cookies-notice-wrapper {
   background: rgba(0, 40, 136, 0.8);
   color: #fff;
 }

--- a/blocks/pure_cookies_notice/view.less
+++ b/blocks/pure_cookies_notice/view.less
@@ -13,10 +13,8 @@
 @font-size: 12px;
 
 .pure-cookies-notice-wrapper {
-  &:not(.pure-cookies-notice-wrapper-preview) {
-    position: fixed;
-    z-index: 1000;
-  }
+  position: fixed;
+  z-index: 1000;
   background: @wrapper-background;
   color: @text-color;
 

--- a/blocks/pure_cookies_notice/view.php
+++ b/blocks/pure_cookies_notice/view.php
@@ -7,7 +7,7 @@
  */
 defined('C5_EXECUTE') or die('Access Denied.');
 $c = Page::getCurrentPage();
-if (empty($previewing) && $c->isEditMode()) {
+if ($c->isEditMode()) {
     $localization = Localization::getInstance();
     $localization->pushActiveContext('ui');
     ?>
@@ -16,17 +16,13 @@ if (empty($previewing) && $c->isEditMode()) {
     </div>
     <?php
     $localization->popActiveContext();
-} elseif (empty($read) || !empty($previewing)) {
+} elseif (empty($read)) {
     $wrapperClasses = [
         $position,
     ];
-    if (empty($previewing)) {
-        $cp = new Permissions($c);
-        if (is_object($cp) && $cp->canViewToolbar()) {
-            $wrapperClasses[] = 'has-toolbar';
-        }
-    } else {
-        $wrapperClasses[] = 'pure-cookies-notice-wrapper-preview';
+    $cp = new Permissions($c);
+    if (is_object($cp) && $cp->canViewToolbar()) {
+        $wrapperClasses[] = 'has-toolbar';
     }
     ?>
     <div id="pure-cookies-notice-<?php echo $bID ?>" class="pure-cookies-notice-wrapper <?php echo implode(' ', $wrapperClasses) ?>" data-bid="<?php echo $bID ?>">
@@ -48,17 +44,13 @@ if (empty($previewing) && $c->isEditMode()) {
         </div>
     </div>
 
+    <script>
+        $(document).ready(function() {
+            $('#pure-cookies-notice-<?php echo $bID ?>').pureCookiesNotify(<?php echo json_encode([
+                'sitewideCookie' => !empty($sitewideCookie),
+                'interactionImpliesOk' => !empty($interactionImpliesOk),
+            ]) ?>);
+        });
+    </script>
     <?php
-    if (empty($previewing)) {
-        ?>
-        <script>
-            $(document).ready(function() {
-                $('#pure-cookies-notice-<?php echo $bID ?>').pureCookiesNotify(<?php echo json_encode([
-                    'sitewideCookie' => !empty($sitewideCookie),
-                    'interactionImpliesOk' => !empty($interactionImpliesOk),
-                ]) ?>);
-            });
-        </script>
-        <?php
-    }
 }


### PR DESCRIPTION
I think to rollback this. Why we need to displaying real data?
Simply show how the notification looks in the selected colors in the color's tab. It is just JS, without changes in controller